### PR TITLE
updated SDK error data payload object property names to match other S…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,0 @@
-# __init__.py
-from .error_monitor import ErrorMonitor
-
-def init_app(app, endpoint):
-    ErrorMonitor(app, endpoint)

--- a/error_monitor.py
+++ b/error_monitor.py
@@ -16,7 +16,6 @@ class ErrorMonitor:
             cls.__is_endpoint_set = True 
 
     def __init__(self, app, endpoint=None):
-        print('hello error monitor')
         self.project_id = str(uuid.uuid4())
         self.app = app
         self.app.register_error_handler(Exception, self.handle_exception)
@@ -46,14 +45,14 @@ class ErrorMonitor:
         raw_error_data = {
             'name': type(e).__name__,
             'message': str(e),
-            'stack_trace': traceback.format_exc(),
+            'stack': traceback.format_exc(),
         }
 
         data = {
             'error': raw_error_data,
             'timestamp':  self.timestamp.isoformat(),
             'handled': was_handled,
-            'project_id': self.project_id
+            'projectID': self.project_id
         }
 
         # Send error data to the monitoring service

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='monitor',
+    name='error_monitor',
     version='0.1.1',
-    py_modules=['sdk'],
-    packages=find_packages(),
     install_requires=[
       'Flask',
       'requests',
-      'uuid'
+      'uuid',
+      'datetime',
+      'traceback'
     ],
     python_requires='>=3.6'
 )


### PR DESCRIPTION
…DKs, and emptied the __init__ file, which had some superfluous code that we weren't using. Instead, the main ErrorMonitor class is imported and instantiated directly in the user's app code. 